### PR TITLE
fix ai bounce

### DIFF
--- a/space_shooter.py
+++ b/space_shooter.py
@@ -162,7 +162,7 @@ def handle_ai_lvl2(yellow, yellow_bullets, second, ai_last_shot_time, velocity, 
 
         # Making the ship "bounce" off the walls
         if yellow.x <= 0:
-            random_move[0] == 2
+            random_move[0] = 2
         elif yellow.x + yellow.width >= BORDER.x:
             yellow.x -= velocity
         elif yellow.y <= 0:

--- a/space_shooter.py
+++ b/space_shooter.py
@@ -235,7 +235,7 @@ def main():
                 if event.key == pygame.K_LCTRL and not ai:
                     soundObj.play()
                     yellow_bullets.append(pygame.Rect(yellow.x, yellow.y + yellow.height//2, 10, 5))
-                if event.key == pygame.K_RCTRL:
+                if event.key == pygame.K_RCTRL or event.key == pygame.K_SPACE:
                     red_bullets.append(pygame.Rect(red.x, red.y + red.height//2, 10, 5))
 
             if event.type == RED_HIT:


### PR DESCRIPTION
@EthanConstantin add context in a comment below about what you think might be the problem

I added a quick fix for an assignment issue, not sure if that solved what you were hoping to

I don't quite understand what a "bounce" is



also I added spacebar as an option for red ship to shoot since my macbook doesn't have right ctrl :/


Also found an issue when "down" and "left ctrl" on mac is pressed, the window zooms out. Perhaps we add another key to use for macs to shoot for the yellow ship